### PR TITLE
Proof of Concept state machine / action validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ db.sqlite3
 .env
 settings_local.py
 /static/*
+.cache

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	py.test --reuse-db --lf

--- a/buggy/test_state.py
+++ b/buggy/test_state.py
@@ -1,0 +1,274 @@
+from collections import defaultdict
+
+import pytest
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from . import models
+from .enums import State, Priority
+
+
+User = get_user_model()
+
+
+class ValidationError(Exception):
+    pass
+
+
+class ListRegistry(defaultdict):
+    def __init__(self):
+        super(ListRegistry, self).__init__(list)
+
+    def register(self, key):
+        def inner(fn):
+            self[key].append(fn)
+            return fn
+        return inner
+
+
+operations_validators = ListRegistry()
+
+
+def validate_action(bug, action):
+    # TODO: catch and aggregate all ValidationErrors
+    for key in action.keys():
+        for validator in operations_validators[key]:
+            validator(bug, action)
+    return True
+
+
+@operations_validators.register(models.Comment)
+def comment_may_not_contain_foo(bug, action):
+    if 'foo' in action[models.Comment]['comment']:
+        raise ValidationError('Comment must not contain foo')
+
+
+state_validators = ListRegistry()
+
+
+@operations_validators.register(models.SetState)
+def run_state_validations(bug, action):
+    next_state = action[models.SetState]['state']
+    for state_change_validator in state_validators[next_state]:
+        state_change_validator(bug, action)
+
+
+def can_come_from(predecessors):
+    def inner(bug, action):
+        if bug.state not in predecessors:
+            raise ValidationError('You cannot go to that state.')
+    return inner
+
+
+resolved_states = [
+    State.RESOLVED_FIXED,
+    State.RESOLVED_UNREPROPDUCIBLE,
+    State.RESOLVED_DUPLICATE,
+    State.RESOLVED_IMPOSSIBLE,
+    State.RESOLVED_NOT_A_BUG,
+]
+
+
+valid_state_go_tos = {
+    State.NEW: [State.ENTRUSTED, State.CLOSED],
+    State.ENTRUSTED: [*resolved_states, State.CLOSED],
+    **{
+        state: [State.REOPENED, State.VERIFIED]
+        for state in resolved_states
+    },
+    State.VERIFIED: [State.REOPENED, State.LIVE],
+}
+
+for state, targets in valid_state_go_tos.items():
+    predecessors = [
+        s for s in State
+        if state in valid_state_go_tos.get(s, [])
+    ]
+    state_validators.register(state)(can_come_from(predecessors))
+
+
+@state_validators.register(State.REOPENED)
+def reopening_requires_comment(bug, action):
+    if models.Comment not in action:
+        raise ValidationError('Reopening bug requires comment')
+
+
+@state_validators.register(State.RESOLVED_DUPLICATE)
+@state_validators.register(State.RESOLVED_NOT_A_BUG)
+def cannot_set_title(bug, action):
+    if models.SetTitle in action:
+        raise ValidationError('Cannot set title')
+
+
+@pytest.fixture()
+def user(db):
+    return User.objects.create_user(
+        email='test@example.com',
+        name='Test User',
+        password='password1',
+    )
+
+
+@pytest.fixture()
+def project(db):
+    return models.Project.objects.create(
+        name='Project',
+    )
+
+
+@pytest.mark.django_db
+def test_rule1(user, project):
+    "Comment must not containt word foo"
+    bug = models.Bug.objects.create(
+        project=project,
+        title='Hello',
+        state=State.ENTRUSTED,
+        priority=Priority.NORMAL,
+        created_by=user,
+    )
+    good_action = {
+        'created_at': timezone.now(),
+        'user': user,
+        models.Comment: {
+            'comment': 'Added a Comment',
+        },
+    }
+    assert validate_action(bug, good_action)
+
+    bad_action = {
+        'created_at': timezone.now(),
+        'user': user,
+        models.Comment: {
+            'comment': 'Added a foo',
+        },
+    }
+    with pytest.raises(ValidationError):
+        validate_action(bug, bad_action)
+
+
+@pytest.mark.django_db
+def test_rule2(user, project):
+    "Cannot set title for some state changes"
+    bug = models.Bug.objects.create(
+        project=project,
+        title='Hello',
+        state=State.ENTRUSTED,
+        priority=Priority.NORMAL,
+        created_by=user,
+    )
+    assert validate_action(bug, {
+        'created_at': timezone.now(),
+        'user': user,
+        models.SetState: {
+            'state': State.RESOLVED_FIXED,
+        },
+        models.SetTitle: {
+            'title': 'New Title',
+        }
+    })
+
+    for weird_state in [State.RESOLVED_DUPLICATE, State.RESOLVED_NOT_A_BUG]:
+        with pytest.raises(ValidationError):
+            assert validate_action(bug, {
+                'created_at': timezone.now(),
+                'user': user,
+                models.SetState: {
+                    'state': weird_state,
+                },
+                models.SetTitle: {
+                    'title': 'New Title',
+                }
+            })
+
+
+@pytest.mark.django_db
+def test_reopening_a_bug_requires_comment(user, project):
+    bug = models.Bug.objects.create(
+        project=project,
+        title='Hello',
+        state=State.RESOLVED_FIXED,
+        priority=Priority.NORMAL,
+        created_by=user,
+    )
+    good_action = {
+        'created_at': timezone.now(),
+        'user': user,
+        models.SetState: {
+            'state': State.REOPENED,
+        },
+        models.Comment: {
+            'comment': 'Fails in IE11',
+        }
+    }
+    assert validate_action(bug, good_action)
+
+    bad_action = {
+        'created_at': timezone.now(),
+        'user': user,
+        models.SetState: {
+            'state': State.REOPENED,
+        },
+    }
+    with pytest.raises(ValidationError):
+        validate_action(bug, bad_action)
+
+
+@pytest.mark.django_db
+def test_can_go_to(user, project):
+    bug = models.Bug.objects.create(
+        project=project,
+        title='Hello',
+        state=State.VERIFIED,
+        priority=Priority.NORMAL,
+        created_by=user,
+    )
+    assert validate_action(bug, {
+        'created_at': timezone.now(),
+        'user': user,
+        models.SetState: {
+            'state': State.REOPENED,
+        },
+        models.Comment: {
+            'comment': 'It does not work if I set my timezone to AEDT',
+        }
+    })
+
+    with pytest.raises(ValidationError):
+        validate_action(bug, {
+            'created_at': timezone.now(),
+            'user': user,
+            models.SetState: {
+                'state': State.RESOLVED_FIXED,
+            },
+        })
+
+    new_bug = models.Bug(
+        project=project,
+        title='Hello',
+        state=State.NEW,
+        priority=Priority.NORMAL,
+    )
+    assert validate_action(new_bug, {
+        'created_at': timezone.now(),
+        'user': user,
+        models.SetState: {
+            'state': State.CLOSED,
+        }
+    })
+    assert validate_action(new_bug, {
+        'created_at': timezone.now(),
+        'user': user,
+        models.SetState: {
+            'state': State.ENTRUSTED,
+        }
+    })
+
+    with pytest.raises(ValidationError):
+        validate_action(new_bug, {
+            'created_at': timezone.now(),
+            'user': user,
+            models.SetState: {
+                'state': State.REOPENED,
+            },
+        })

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = testproj.settings
+python_files = tests.py test_*.py *_tests.py

--- a/requirements.in
+++ b/requirements.in
@@ -10,3 +10,5 @@ babel
 django-extensions
 django-compressor
 django-pyscss
+pytest
+pytest-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,10 @@ django-pyscss==2.0.2
 django==1.11
 markdown==2.6.8
 psycopg2==2.7.1
+py==1.4.33                # via pytest
 pyscss==1.3.5             # via django-pyscss
+pytest-django==3.1.2
+pytest==3.0.7
 pytz==2017.2              # via babel, django
 rcssmin==1.0.6            # via django-compressor
 rjsmin==1.0.12            # via django-compressor


### PR DESCRIPTION
Here's an idea I had for how to manage the state machine.

Terms:

**Action** the Action model, the only way to modify state. Somewhat similar to a Django migration. Basically a collection of operations + timestamp + user.

**Operation** SetState, Comment, etc.

Instead of treating SetState as different from any other operation, I decided to come up with this `validate_action` function. It loops through all of the operations per an action and runs any validations against them. In the validator for SetState it also runs a similar validation cycle against the next state.

I just made up some rules for testing, but I think it's fairly illustrative of what is possible. This is less declarative than I would have liked, but I think it could serve as building blocks if we want. I don't have the buggy_states.yaml, and I don't really remember any of the real rules for state transitions, but I think this model makes it possible to add any rules we want.

By building this separate from the actual operations, we are able to build different life cycles if we wanted. If we were to do that, we could build a collection of generic validator functions that you would just register to whatever you wanted.

w.r.t to the way I was representing actions in the tests, that was just to have something to use. I don't think we should represent them with plain dicts later on. I do kind of like the idea of representing it as an iterable of operations.