### PR TITLE
Allow commenting/fixes bugs from commit messages

### DIFF
--- a/buggy/test/test_views.py
+++ b/buggy/test/test_views.py
@@ -1,0 +1,103 @@
+import json
+
+from django.urls import reverse
+
+from buggy.webhook import get_bugs_from_commit_message, process_commit, validate_signature
+from buggy.enums import State
+
+from .fixtures import bug, project, user
+
+
+def test_get_bugs_from_commit_message():
+    assert get_bugs_from_commit_message('#1234') == ({'1234'}, set())
+    assert get_bugs_from_commit_message('foo bar #1234 and #456') == ({'1234', '456'}, set())
+    assert get_bugs_from_commit_message('fo#1234') == (set(), set())
+
+    assert get_bugs_from_commit_message('fixes #123') == (set(), {'123'})
+    assert get_bugs_from_commit_message('fixes #123 and fixes #456') == (set(), {'123', '456'})
+    assert get_bugs_from_commit_message('fixes #123 and mentions #456') == ({'456'}, {'123'})
+    assert get_bugs_from_commit_message('fixed #123') == (set(), {'123'})
+    assert get_bugs_from_commit_message('fix #123') == (set(), {'123'})
+    assert get_bugs_from_commit_message('fix bug #123') == (set(), {'123'})
+    assert get_bugs_from_commit_message('fix buggy #123') == (set(), {'123'})
+
+
+def test_mention(bug):
+    message = "this is related to #{}".format(bug.number)
+
+    commit = {
+        "author": {
+            "email": bug.created_by.email,
+        },
+        "id": "dfe96070ea1f472fb3aa35f8a64ede598cb970e0",
+        "message": message,
+    }
+    process_commit(commit)
+    assert len(bug.actions.all()) == 2
+    action = bug.actions.last()
+    assert message in action.comment.comment
+
+    # don't do duplicate comments (pushes from other branches)
+    process_commit(commit)
+    assert len(bug.actions.all()) == 2
+
+
+def test_resolve(bug):
+    message = "fixes #{}".format(bug.number)
+
+    commit = {
+        "author": {
+            "email": bug.created_by.email,
+        },
+        "id": "dfe96070ea1f472fb3aa35f8a64ede598cb970e0",
+        "message": message,
+    }
+    process_commit(commit)
+    assert len(bug.actions.all()) == 2
+    action = bug.actions.last()
+    assert message in action.comment.comment
+    assert action.setstate.state == State.RESOLVED_FIXED
+
+    # don't do duplicate comments (pushes from other branches)
+    process_commit(commit)
+    assert len(bug.actions.all()) == 2
+
+    commit = {
+        "author": {
+            "email": bug.created_by.email,
+        },
+        "id": "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc",
+        "message": message,
+    }
+
+    # needs to validate that the state transition is valid
+    process_commit(commit)
+    action = bug.actions.last()
+    assert not hasattr(action, 'setstate')
+
+
+def test_view(client, bug, settings):
+    settings.GIT_COMMIT_WEBHOOK_SECRET = None
+
+    message = "fixes #{}".format(bug.number)
+    response = client.post(reverse('buggy:git_commit_webhook'), json.dumps({
+        "commits": [
+            {
+                "author": {
+                    "email": bug.created_by.email,
+                },
+                "id": "fe0aeff2fe77208d0c5ed4e7b3c1f89ce41a5d35",
+                "message": message,
+            }
+        ],
+    }), content_type='application/json')
+
+    assert response.status_code == 201
+    action = bug.actions.last()
+    assert message in action.comment.comment
+    assert action.setstate.state == State.RESOLVED_FIXED
+
+
+def test_signature():
+    assert validate_signature(b'secret', b'body', 'sha1=a18991ff7e4513a1c2d2ee51e3a8e99ca891d9cd')
+    assert not validate_signature(b'secret', b'no', 'sha1=a18991ff7e4513a1c2d2ee51e3a8e99ca891d9cd')

--- a/buggy/urls.py
+++ b/buggy/urls.py
@@ -14,4 +14,7 @@ urlpatterns = [
     url(r'^markdown-preview/$',
         csrf_exempt(views.MarkdownPreviewView.as_view()),
         name='markdown_preview'),
+    url(r'^git-commit-webhook/$',
+        csrf_exempt(views.GitCommitWebhookView.as_view()),
+        name='git_commit_webhook')
 ]

--- a/buggy/webhook.py
+++ b/buggy/webhook.py
@@ -1,0 +1,65 @@
+import re
+import hmac
+import hashlib
+
+from django.contrib.auth import get_user_model
+
+from .models import Bug
+from .mutation import BuggyBugMutator
+
+User = get_user_model()
+
+
+BUG_RE = re.compile(r'(fix(?:e[ds])?(?:\s+bug(?:gy)?)?)?(?:\s+|^)#([0-9]+\b)', re.IGNORECASE)
+
+
+def validate_signature(secret, request_body, signature):
+    computed_signature = 'sha1={}'.format(hmac.new(secret, request_body, hashlib.sha1).hexdigest())
+    return hmac.compare_digest(signature, computed_signature)
+
+
+def get_bugs_from_commit_message(msg):
+    fixes = set()
+    mentions = set()
+    for match in BUG_RE.findall(msg):
+        if match[0]:
+            fixes.add(match[1])
+        else:
+            mentions.add(match[1])
+    return (mentions, fixes)
+
+
+def process_commit(commit):
+    try:
+        user = User.objects.get(email=commit['author']['email'])
+    except User.DoesNotExist:
+        return
+
+    mentions, fixes = get_bugs_from_commit_message(commit['message'])
+    for bug_number in mentions | fixes:
+        try:
+            bug = Bug.objects.get_by_number(bug_number)
+        except Bug.DoesNotExist:
+            pass
+        else:
+            past_comments = (
+                action.comment.comment for action in bug.actions.all() if hasattr(action, 'comment')
+            )
+            if not any(commit['id'] in c for c in past_comments):
+                mutator = BuggyBugMutator(bug=bug, user=user)
+                actions = {a[0] for a in mutator.action_choices()}
+
+                comment = "{} {} the bug in commit `{}`:\n\n{}".format(
+                    user.get_short_name(),
+                    'fixed' if bug_number in fixes else 'mentioned',
+                    commit['id'],
+                    commit['message'],
+                )
+                if bug_number in fixes and 'resolved-fixed' in actions:
+                    action = 'resolved-fixed'
+                else:
+                    action = 'comment'
+                mutator.process_action({
+                    'comment': comment,
+                    'action': action,
+                })

--- a/testproj/settings.py
+++ b/testproj/settings.py
@@ -145,3 +145,7 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 THUMBNAIL_PRESERVE_FORMAT = True
 
 SITE_ID = 1
+
+# Disables web hook, set to a secret random string or None (unsafe, disables
+# authentication completely) to enable.
+GIT_COMMIT_WEBHOOK_SECRET = os.urandom(16)


### PR DESCRIPTION
Uses the github format and signature for the webhook.

I had to change the interface of BugMutator a little, to just take data instead of a form. We need to reuse the BugMutator for validation and processing, but we don't have a form in the webhook handler.

Fixes #12.